### PR TITLE
fix: masscan scanner program error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,9 @@
 
 FROM golang:1.21-bullseye AS builder
 
-WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
+
+WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -18,15 +19,20 @@ FROM debian:bookworm-slim
 ENV TZ=Etc/UTC \
     CHROME_BIN=/usr/bin/chromium
 
-RUN apt-get update && \
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates \
-        chromium \
-        dumb-init \
-        fonts-dejavu-core \
-        nmap \
-        python3 \
+    ca-certificates \
+    chromium \
+    dumb-init \
+    fonts-dejavu-core \
+    nmap \
+    masscan \
+    python3 \
+    libcap2-bin \
     && rm -rf /var/lib/apt/lists/*
+
+RUN setcap CAP_NET_RAW+eip /usr/bin/masscan
 
 RUN useradd --system --home /app --shell /usr/sbin/nologin appuser
 

--- a/backend/internal/scanner/masscan_engine.go
+++ b/backend/internal/scanner/masscan_engine.go
@@ -65,10 +65,6 @@ func (me *MasscanEngine) SetRate(rate int) {
 func isMasscanAvailable() bool {
 	masscanPath, err := exec.LookPath("masscan")
 	if err != nil {
-		// 在 PATH 中找不到 masscan
-		fmt.Println("========Masscan Check FAILED=========")
-		fmt.Printf("Error: 'masscan' executable not found in PATH: %v\n", err)
-		fmt.Println("=======================================")
 		return false
 	}
 	fmt.Printf("✓ 'masscan' executable found at: %s\n", masscanPath)
@@ -131,21 +127,11 @@ func (me *MasscanEngine) masscanDiscovery(targets []string, ports []int) (map[st
 
 	fmt.Printf("Executing: masscan --rate %d -p %s %s\n", me.rate, portRanges, strings.Join(targets, " "))
 
-	fmt.Println("======masscan2======")
-	fmt.Println("masscan", args)
-	fmt.Println("======masscan2======")
-
 	cmd := exec.Command("masscan", args...)
 	output, err := cmd.Output()
 	if err != nil {
-		fmt.Println("======masscan3======")
-		fmt.Println(err.Error())
-		fmt.Println("======masscan3======")
 		return nil, fmt.Errorf("masscan execution failed: %w", err)
 	}
-	fmt.Println("======masscan4======")
-	fmt.Println(output)
-	fmt.Println("======masscan4======")
 
 	// 解析 Masscan JSON 输出
 	return me.parseMasscanOutput(output)
@@ -371,10 +357,6 @@ func (me *MasscanEngine) isAvailable() bool {
 func (me *MasscanEngine) isNmapAvailable() bool {
 	cmd := exec.Command("nmap", "--version")
 	if err := cmd.Run(); err != nil {
-		fmt.Println("===========nmap======")
-		fmt.Println(err.Error())
-		fmt.Println("===========nmap======")
-
 		return false
 	}
 	return true


### PR DESCRIPTION
将Debian软件包源替换为清华大学镜像源
本身Docker未安装masscan，在Dockerfile中增加masscan安装
masscan 自身使用 `--version` 命令的返回状态为1，所以无法使用`--version`的方式校验是否存在，改用命令路径检测的方式
masscan本身需要root启动，dockerfile增加libcap2-bin来增加masscan执行权限
masscan命令args增加逻辑修改
更新masscan的返回解析器