### PR TITLE
Fix docker deployment error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-bullseye AS builder
+FROM golang:1.24-bullseye AS builder
+
+# 1. Install libpcap-dev for CGO to link against
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libpcap-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 ENV GOPROXY=https://goproxy.cn,direct
@@ -10,8 +15,12 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/server ./cmd/server && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/init-admin ./cmd/init-admin
+# 2. Remove CGO_ENABLED=0 so Go can link with libpcap
+# RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/server ./cmd/server && \
+#     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/bin/init-admin ./cmd/init-admin
+RUN GOOS=linux GOARCH=amd64 go build -o /app/bin/server ./cmd/server && \
+    GOOS=linux GOARCH=amd64 go build -o /app/bin/init-admin ./cmd/init-admin
+    # Note: We keep the GOOS/GOARCH flags for cross-compilation environment consistency
 
 FROM debian:bookworm-slim
 
@@ -26,6 +35,8 @@ RUN apt-get update && \
         fonts-dejavu-core \
         nmap \
         python3 \
+# 3. Important: libpcap is required at runtime for the binary
+        libpcap0.8 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --system --home /app --shell /usr/sbin/nologin appuser

--- a/backend/configs/config.docker.yaml
+++ b/backend/configs/config.docker.yaml
@@ -6,7 +6,7 @@ jwt:
   secret: "change-me-in-production"
 
 database:
-  host: localhost
+  host: db
   port: 5432
   user: arl
   password: arlpass
@@ -16,7 +16,7 @@ database:
   max_open_conns: 100
 
 redis:
-  host: localhost
+  host: redis
   port: 6379
   password: ""
   db: 0


### PR DESCRIPTION
1、修复`ERROR [backend builder 4/6] RUN go mod download`报错：修改`backend/Dockerfile`中的`Go`版本

2、修复`undefined: pcapXXX`报错：`gopacket/pcap` 依赖于 C 库，因此需要启用 CGO 并确保所需的开发包（如`libpcap-dev`）在构建器阶段可用

3、修复`init-admin`初始化失败报错：`[error] failed to initialize database`
